### PR TITLE
Removed debugging print statements, made sendRaw return bool

### DIFF
--- a/BURT_can.h
+++ b/BURT_can.h
@@ -71,7 +71,7 @@ class BurtCan {
 		void update();
 
 		/// Sends a byte array over the CAN bus with the given ID.
-		void sendRaw(uint32_t id, uint8_t data[8], int length);
+		bool sendRaw(uint32_t id, uint8_t data[8], int length);
 
 		/// Encodes the given message and fields then sends it using #sendRaw.
 		bool send(uint32_t id, const void* message, const pb_msgdesc_t* fields);


### PR DESCRIPTION
Removed print statements to cleanup and stop Protobuf interference. sendRaw now returns bool instead of void to this end.